### PR TITLE
Simnibs

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -189,6 +189,15 @@ use ()
         fi
         . $FREESURFER_HOME/SetUpFreeSurfer.sh
 
+		elif [[ $ENV_NAME == 'simnibs' ]]
+		then
+				if [[ $PATH == *conda* ]]
+				then
+					export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/conda/ {next} {print}' | sed 's/:*$//'`
+					echo "Warning: SimNiBS uses the system python installation!"
+					echo "(Ana)conda is now removed from your path."
+				fi
+				
     else
         echo "Unknown environment/programme: $ENV_NAME"
         return 1

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -4,6 +4,9 @@
 # (from the same dir)
 current_dir="$(dirname "$BASH_SOURCE")"
 
+# add bin-folder from configurations to path, though these will be scripts
+PATH=${current_dir}/bin:${PATH}
+
 # Only run these on isis, AND make sure this is a login shell
 # (otherwise rsync and scp and the likes will die!)
 #if [[ $HOSTNAME == 'isis' ]] && [[ ${DISPLAY} ]]
@@ -19,9 +22,6 @@ DEFAULT_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 
 export MINDLABPROJ='NA'
 export MINDLABENV='not set'
-
-# add bin-folder from configurations to path, though these will be scripts
-PATH=${current_dir}/bin:${PATH}
 
 gotoproj ()
 {
@@ -189,14 +189,16 @@ use ()
         fi
         . $FREESURFER_HOME/SetUpFreeSurfer.sh
 
-		elif [[ $ENV_NAME == 'simnibs' ]]
+	elif [[ $ENV_NAME == 'simnibs' ]]
+	then
+	    if [[ $PATH == *conda* ]]
 		then
-				if [[ $PATH == *conda* ]]
-				then
-					export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/conda/ {next} {print}' | sed 's/:*$//'`
-					echo "Warning: SimNiBS uses the system python installation!"
-					echo "(Ana)conda is now removed from your path."
-				fi
+			export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/conda/ {next} {print}' | sed 's/:*$//'`
+			echo "Warning: SimNiBS uses the system python installation!"
+			echo "(Ana)conda is now removed from your path."
+	    fi
+        export SIMNIBSDIR=/usr/local/common/simnibs
+        source $SIMNIBSDIR/simnibs_conf.sh
 				
     else
         echo "Unknown environment/programme: $ENV_NAME"


### PR DESCRIPTION
`use simnibs` will now unload anaconda from the PATH and setup the environment for simnibs. Note that freesurfer is enabled by default on CFIN servers.