### PR TITLE
Deprecate submit_to_isis-script

### DIFF
--- a/bin/submit_to_isis
+++ b/bin/submit_to_isis
@@ -1,49 +1,65 @@
 #!/bin/bash
-# This is a convenience script to allow submitting a job to isis that is 
+# NB This script is _deprecated_ as of August 2016. Use the new
+# `submit_to_cluster`-wrapper instead, located in `stormdb-python/bin`
+
+# This is a convenience script to allow submitting a job to isis that is
 # capable of using multiple computational theads. An example of such is
 # Maxfilter, and the usage of this script to submit a 4-thread run could be:
 # submit_to_isis 4 "/neuro/bin/util/maxfilter -f somefile.fif -o somefile_tsss_mc.fif -st 16 -corr 0.9 -movecomp -hp somefile_tsss.pos -v | tee somefile_tsss.log"
 # Note that you should apply quotation marks (") around a complex command!
 
+echo "##################################################################"
+echo "WARNING! This function is about to be retired. Please learn to use"
+echo "  stormdb-python/bin/submit_to_cluster"
+echo "instead (see submit_to_cluster --help for usage)."
+echo "This function will continue in 5 seconds (hit Ctrl-C to quit.)"
+echo "##################################################################"
+sleep 5
+
 NTHREADS=$1
 EXEC_CMD=${@:2}
 
-if [[ $NTHREADS -lt 1 || $NTHREADS -gt 12 ]]
-then
-    echo "Usage: `basename $0` <number of threads> <command to execute>"
-    echo "  where"
-    echo "      <number of threads> is in the range 1-12"
-    echo "      <command to execute> is a multi-parameter command, such as"
-    echo "          \"/neuro/bin/util/maxfilter -f in.fif -o out.fif -v | tee out.log\""
-    exit 1
-fi
+# MINDLABPROJ not set, randomly choose first project...
+if [[ $MINDLABPROJ == NA ]] && set_mindlabproj 1
 
-echo "Submitting ${EXEC_CMD} on ${NTHREADS} threads"
-echo "Check job_scripts/ in current working directory for output."
-mkdir -p job_scripts
+submit_to_cluster -n $NTHREADS -q isis.q ${EXEC_CMD}
 
-cat > submit_job.sh <<EOT
-#!/bin/bash
-
-# Pass on all environment variables
-#$ -V
-# Operate in current working directory
-#$ -cwd
-#$ -N submit_to_isis
-#$ -o job_scripts/submit_to_isis.output.\$JOB_ID
-#$ -e job_scripts/submit_to_isis.errors.\$JOB_ID
-#$ -q isis.q
-#$ -pe threaded ${NTHREADS}
-
-export OMP_NUM_THREADS=\$NSLOTS
-
-echo "Executing following command on \$NSLOTS threads:"
-echo "${EXEC_CMD}"
-
-${EXEC_CMD}
-
-echo "Done executing"
-EOT
-
-qsub submit_job.sh
-rm submit_job.sh
+# if [[ $NTHREADS -lt 1 || $NTHREADS -gt 12 ]]
+# then
+#     echo "Usage: `basename $0` <number of threads> <command to execute>"
+#     echo "  where"
+#     echo "      <number of threads> is in the range 1-12"
+#     echo "      <command to execute> is a multi-parameter command, such as"
+#     echo "          \"/neuro/bin/util/maxfilter -f in.fif -o out.fif -v | tee out.log\""
+#     exit 1
+# fi
+#
+# echo "Submitting ${EXEC_CMD} on ${NTHREADS} threads"
+# echo "Check job_scripts/ in current working directory for output."
+# mkdir -p job_scripts
+#
+# cat > submit_job.sh <<EOT
+# #!/bin/bash
+#
+# # Pass on all environment variables
+# #$ -V
+# # Operate in current working directory
+# #$ -cwd
+# #$ -N submit_to_isis
+# #$ -o job_scripts/submit_to_isis.output.\$JOB_ID
+# #$ -e job_scripts/submit_to_isis.errors.\$JOB_ID
+# #$ -q isis.q
+# #$ -pe threaded ${NTHREADS}
+#
+# export OMP_NUM_THREADS=\$NSLOTS
+#
+# echo "Executing following command on \$NSLOTS threads:"
+# echo "${EXEC_CMD}"
+#
+# ${EXEC_CMD}
+#
+# echo "Done executing"
+# EOT
+#
+# qsub submit_job.sh
+# rm submit_job.sh

--- a/bin/submit_to_isis
+++ b/bin/submit_to_isis
@@ -20,9 +20,9 @@ NTHREADS=$1
 EXEC_CMD=${@:2}
 
 # MINDLABPROJ not set, randomly choose first project...
-if [[ $MINDLABPROJ == NA ]] && set_mindlabproj 1
+if [[ ${MINDLABPROJ} == 'NA' ]]; then set_mindlabproj 1; fi
 
-submit_to_cluster -n $NTHREADS -q isis.q ${EXEC_CMD}
+submit_to_cluster -n $NTHREADS -q isis.q "${EXEC_CMD}"
 
 # if [[ $NTHREADS -lt 1 || $NTHREADS -gt 12 ]]
 # then

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -88,20 +88,16 @@ set_mindlabproj ()
     echo "Environment variable MINDLABPROJ set to ${PROJLIST[$((${pnum} - 1))]}"
     export MINDLABPROJ=${PROJLIST[$(($pnum - 1))]}
 
-    # check if fs_subjects_dir is present in the selected project and sets that
-    # to $SUBJECTS_DIR if present
-    if [[ -d /projects/$MINDLABPROJ/scratch/fs_subjects_dir ]]; then
-        export SUBJECTS_DIR=/projects/$MINDLABPROJ/scratch/fs_subjects_dir
-    else
-        echo "Folder fs_subjects_dir not found in scratch."
-        echo -n "Would you like to create it now? [Y/n] "
-        read ans
-        if [[ $ans == "" ]] || [[ $ans == y ]] || [[ $ans == Y ]]; then
-            mkdir /projects/$MINDLABPROJ/scratch/fs_subjects_dir
-            export SUBJECTS_DIR=/projects/$MINDLABPROJ/scratch/fs_subjects_dir
-        fi
-    fi
-    echo "SUBJECTS_DIR set to: $SUBJECTS_DIR"
+		# Try to be a bit smart about a subjects_dir existing, but don't force
+		# response from the user if not found (just silently move on)
+		SUBJECTS_DIR=$(find /projects/$MINDLABPROJ/scratch -maxdepth 1 -type d \
+									 -name '*subjects_dir*'| head -n1)
+		if [[ -d $SUBJECTS_DIR ]]; then
+			export SUBJECTS_DIR
+			echo "SUBJECTS_DIR set to: $SUBJECTS_DIR"
+		else
+			unset SUBJECTS_DIR  # since this script is source'd
+		fi
 
 }
 
@@ -199,7 +195,7 @@ use ()
 	    fi
         export SIMNIBSDIR=/usr/local/common/simnibs
         source $SIMNIBSDIR/simnibs_conf.sh
-				
+
     else
         echo "Unknown environment/programme: $ENV_NAME"
         return 1

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+# hard-code this location for now, but beware...
+meeg_cfin_dir=/usr/local/common/meeg-cfin
+PATH=${meeg_cfin_dir}/stormdb-python/bin:${PATH}
+############
+# NB DEPRECATE THIS! no 'bin' in configurations...
 # This will allow us to call additional scripts relative to the present one
 # (from the same dir)
 current_dir="$(dirname "$BASH_SOURCE")"
-
 # add bin-folder from configurations to path, though these will be scripts
 PATH=${current_dir}/bin:${PATH}
+###############
 
 # Only run these on isis, AND make sure this is a login shell
 # (otherwise rsync and scp and the likes will die!)
@@ -88,18 +93,19 @@ set_mindlabproj ()
     echo "Environment variable MINDLABPROJ set to ${PROJLIST[$((${pnum} - 1))]}"
     export MINDLABPROJ=${PROJLIST[$(($pnum - 1))]}
 
-		# Try to be a bit smart about a subjects_dir existing, but don't force
-		# response from the user if not found (just silently move on)
-		SUBJECTS_DIR=$(find /projects/$MINDLABPROJ/scratch -maxdepth 1 -type d \
-									 -name '*subjects_dir*'| head -n1)
-		if [[ -d $SUBJECTS_DIR ]]; then
-			export SUBJECTS_DIR
-			echo "SUBJECTS_DIR set to: $SUBJECTS_DIR"
-		else
-			unset SUBJECTS_DIR  # since this script is source'd
-		fi
+    # Try to be a bit smart about a subjects_dir existing, but don't force
+    # response from the user if not found (just silently move on)
+    SUBJECTS_DIR=$(find /projects/$MINDLABPROJ/scratch/ -maxdepth 1 -type d \
+        -name '*subjects_dir*'| head -n1)
+    if [[ -d $SUBJECTS_DIR ]]; then
+        export SUBJECTS_DIR
+        echo "SUBJECTS_DIR set to: $SUBJECTS_DIR"
+    else
+        unset SUBJECTS_DIR  # since this script is source'd
+    fi
 
 }
+export -f set_mindlabproj  # export function for subshells/children!
 
 use ()
 {


### PR DESCRIPTION
`submit_to_cluster -q isis.q ...` should be used instead of `submit_to_isis`

Changes made to `setup_environment.sh` to add the new script (now in `stormdb-python`) to the path. Attempt made to wrap  `submit_to_isis` to use the new script, bugs may ensue...