### PR TITLE
deprecated submit_to_isis

### DIFF
--- a/bin/submit_to_isis
+++ b/bin/submit_to_isis
@@ -9,12 +9,12 @@
 # Note that you should apply quotation marks (") around a complex command!
 
 echo "##################################################################"
-echo "WARNING! This function is about to be retired. Please learn to use"
+echo "ERROR! This function has been retired. Please learn to use"
 echo "  stormdb-python/bin/submit_to_cluster"
 echo "instead (see submit_to_cluster --help for usage)."
-echo "This function will continue in 5 seconds (hit Ctrl-C to quit.)"
 echo "##################################################################"
-sleep 5
+
+exit 1
 
 NTHREADS=$1
 EXEC_CMD=${@:2}

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -5,11 +5,6 @@
 current_dir="$(dirname "$BASH_SOURCE")"
 meeg_cfin_dir=$(dirname ${current_dir})
 PATH=${meeg_cfin_dir}/stormdb-python/bin:${PATH}
-############
-# NB DEPRECATE THIS! no 'bin' in configurations...
-# add bin-folder from configurations to path, though these will be scripts
-PATH=${current_dir}/bin:${PATH}
-###############
 
 DEFAULT_PS1=${PS1}
 DEFAULT_PATH=${PATH}


### PR DESCRIPTION
Once isis is no longer, deprecate `submit_to_isis`. This depends on

meeg-cfin/stormdb-python#22
