### PR TITLE
dont export bash functions for children

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -214,4 +214,5 @@ unuse ()
     export MINDLABENV='not set'
 }
 
-export -f set_mindlabproj use unuse  # export functions for subshells/children!
+# This could be a problem for qsub, try to not rely on functions, only MINDLABPROJ
+# export -f set_mindlabproj use unuse  # export functions for subshells/children!


### PR DESCRIPTION
Turns out exporting with the -f flag gives all sorts of errors in a qsub-run. It's also not necessary, since the -V option automatically provides things like anaconda python, assuming that a `use something` command is issued in the terminal that submits the job.